### PR TITLE
Remove GetDesignItemInfo and rework LoadDesignItemsAsync

### DIFF
--- a/Nexar.Client/Nexar.Client.csproj
+++ b/Nexar.Client/Nexar.Client.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.7.0" />
-    <PackageReference Include="StrawberryShake.Transport.Http" Version="12.7.0" />
+    <PackageReference Include="StrawberryShake.CodeGeneration.CSharp.Analyzers" Version="12.17.0" />
+    <PackageReference Include="StrawberryShake.Transport.Http" Version="12.17.0" />
   </ItemGroup>
 
 </Project>

--- a/Nexar.Client/Resources/Queries.graphql
+++ b/Nexar.Client/Resources/Queries.graphql
@@ -40,31 +40,7 @@ query GetProjects($workspaceUrl: String!, $cursor: String!) {
   }
 }
 
-query GetDesignItemInfo($id: ID!) {
-  desProjectById (id: $id) {
-    name
-    description
-    design {
-      workInProgress {
-        variants {
-          pcb {
-            designItems {
-              totalCount
-              pageInfo {
-                startCursor
-                hasNextPage
-                hasPreviousPage
-                endCursor
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-query GetDesignItems($id: ID!, $cursor: String!, $count: Int!) {
+query GetDesignItems($id: ID!, $cursor: String, $count: Int!) {
   desProjectById (id: $id) {
     name
     description

--- a/Nexar.Client/schema.graphql
+++ b/Nexar.Client/schema.graphql
@@ -8,6 +8,8 @@ scalar Map
 
 scalar Time
 
+scalar Any
+
 type Query {
   "Fetches an object given its ID."
   node("ID of the object." id: ID!): Node
@@ -3589,6 +3591,8 @@ input AdmEvtSendAppNotificationInput {
   destinationApplicationId: String!
   "Identifier of object the event is generate for (project, workspace, part, etc)."
   subject: String
+  "customData is destination application specified extra data."
+  customData: Any
 }
 
 enum AdmEventType {


### PR DESCRIPTION
`GetDesignItemInfo` does not look needed per the current design (maybe it was experimental?).
The absolutely same pagination may be performed without it.

NB This does not fixes the recent mysterious StrawberryShake exception on loading projects.
It happens once and maybe safely (seemingly) ignored. TBC.